### PR TITLE
fix(#175): `Ntfctn`>`CreDtTm` is optional

### DIFF
--- a/src/Camt054/Decoder/Message.php
+++ b/src/Camt054/Decoder/Message.php
@@ -19,10 +19,17 @@ class Message extends BaseMessageDecoder
         $notifications = [];
 
         $xmlNotifications = $this->getRootElement($document)->Ntfctn;
+        $fallbackCreationDate = $message->getGroupHeader()->getCreatedOn();
         foreach ($xmlNotifications as $xmlNotification) {
+            $recordDateStr = (string) $xmlNotification->CreDtTm;
+            if ($recordDateStr === '') {
+                $notificationDate = $fallbackCreationDate;
+            } else {
+                $notificationDate = $this->dateDecoder->decode($recordDateStr);
+            }
             $notification = new Camt054DTO\Notification(
                 (string) $xmlNotification->Id,
-                $this->dateDecoder->decode((string) $xmlNotification->CreDtTm),
+                $notificationDate,
                 $this->getAccount($xmlNotification)
             );
 

--- a/test/Unit/Camt054/EndToEndTest.php
+++ b/test/Unit/Camt054/EndToEndTest.php
@@ -40,6 +40,22 @@ class EndToEndTest extends Framework\TestCase
         return (new MessageFormat\V08())->getDecoder()->decode($dom);
     }
 
+    protected function getv8MessageCredTmHeaderOnly(): Message
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->load('test/data/camt054.v8-grphdr-credttm.xml');
+
+        return (new MessageFormat\V08())->getDecoder()->decode($dom);
+    }
+
+    protected function getv8MessageCredTmHeaderAndNotification(): Message
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->load('test/data/camt054.v8-ntfctn-credttm.xml');
+
+        return (new MessageFormat\V08())->getDecoder()->decode($dom);
+    }
+
     public function testGroupHeader(): void
     {
         $messages = [
@@ -375,5 +391,22 @@ class EndToEndTest extends Framework\TestCase
                 }
             }
         }
+    }
+
+    public function testCreditDateInHeaderOnly(): void
+    {
+        $message = $this->getv8MessageCredTmHeaderOnly();
+
+        self::assertSame('2025-03-25T21:18:34+01:00', $message->getGroupHeader()->getCreatedOn()->format(DATE_ATOM));
+        self::assertSame('2025-03-25T21:18:34+01:00', $message->getRecords()[0]->getCreatedOn()->format(DATE_ATOM));
+    }
+
+    public function testCreditDateInHeaderAndNotificationOnly(): void
+    {
+        $message = $this->getv8MessageCredTmHeaderAndNotification();
+
+        self::assertSame('2025-03-25T21:18:34+01:00', $message->getGroupHeader()->getCreatedOn()->format(DATE_ATOM));
+        $records = $message->getRecords();
+        self::assertSame('2025-03-25T21:17:59+01:00', $records[0]->getCreatedOn()->format(DATE_ATOM));
     }
 }

--- a/test/data/camt054.v8-grphdr-credttm.xml
+++ b/test/data/camt054.v8-grphdr-credttm.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.08" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <BkToCstmrDbtCdtNtfctn>
+        <GrpHdr>
+            <MsgId>COBADEFF250326012345678</MsgId>
+            <CreDtTm>2025-03-25T21:18:34+01:00</CreDtTm>
+        </GrpHdr>
+        <Ntfctn>
+            <Id>250326012345678</Id>
+            <Acct>
+                <Id>
+                    <IBAN>DE91100000000123456789</IBAN>
+                </Id>
+                <Svcr>
+                    <FinInstnId>
+                        <BICFI>COBADEFF</BICFI>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Ntry>
+                <Amt Ccy="EUR">47.4</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>
+                    <Cd>INFO</Cd>
+                </Sts>
+                <ValDt>
+                    <Dt>2025-03-25</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RRCT</Cd>
+                            <SubFmlyCd>ESCT</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <EndToEndId>NOTPROVIDED</EndToEndId>
+                        </Refs>
+                        <RltdPties>
+                            <Dbtr>
+                                <Pty>
+                                    <Nm>Remote Party</Nm>
+                                </Pty>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>DE02200505501015871393</IBAN>
+                                </Id>
+                            </DbtrAcct>
+                            <Cdtr>
+                                <Pty>
+                                    <Nm>MyBigCompany GmbH</Nm>
+                                </Pty>
+                            </Cdtr>
+                        </RltdPties>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Ntfctn>
+    </BkToCstmrDbtCdtNtfctn>
+</Document>

--- a/test/data/camt054.v8-ntfctn-credttm.xml
+++ b/test/data/camt054.v8-ntfctn-credttm.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.08" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <BkToCstmrDbtCdtNtfctn>
+        <GrpHdr>
+            <MsgId>COBADEFF250326012345678</MsgId>
+            <CreDtTm>2025-03-25T21:18:34+01:00</CreDtTm>
+        </GrpHdr>
+        <Ntfctn>
+            <Id>250326012345678</Id>
+            <CreDtTm>2025-03-25T21:17:59+01:00</CreDtTm>
+            <Acct>
+                <Id>
+                    <IBAN>DE91100000000123456789</IBAN>
+                </Id>
+                <Svcr>
+                    <FinInstnId>
+                        <BICFI>COBADEFF</BICFI>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Ntry>
+                <Amt Ccy="EUR">47.4</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>
+                    <Cd>INFO</Cd>
+                </Sts>
+                <ValDt>
+                    <Dt>2025-03-25</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RRCT</Cd>
+                            <SubFmlyCd>ESCT</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <EndToEndId>NOTPROVIDED</EndToEndId>
+                        </Refs>
+                        <RltdPties>
+                            <Dbtr>
+                                <Pty>
+                                    <Nm>Remote Party</Nm>
+                                </Pty>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>DE02200505501015871393</IBAN>
+                                </Id>
+                            </DbtrAcct>
+                            <Cdtr>
+                                <Pty>
+                                    <Nm>MyBigCompany GmbH</Nm>
+                                </Pty>
+                            </Cdtr>
+                        </RltdPties>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Ntfctn>
+    </BkToCstmrDbtCdtNtfctn>
+</Document>


### PR DESCRIPTION
This PR fixes keeps the camt parser from throwing on optinal DateTime fields 